### PR TITLE
Increase markdup memory usage to avoid failure

### DIFF
--- a/TCP/FastqToTargetedAlignedBam.wdl
+++ b/TCP/FastqToTargetedAlignedBam.wdl
@@ -250,7 +250,7 @@ task mark {
      runtime {
              docker_image: "registry.gsc.wustl.edu/genome/sort-mark-duplicates:2"
              cpu: "8"
-             memory: "20 G"
+             memory: "50 G"
              queue: queue
              job_group: jobGroup
      }

--- a/germlineQC/FastqToTargetedAlignedBamWithGermlineQC.wdl
+++ b/germlineQC/FastqToTargetedAlignedBamWithGermlineQC.wdl
@@ -252,7 +252,7 @@ task mark {
      runtime {
              docker_image: "registry.gsc.wustl.edu/genome/sort-mark-duplicates:2"
              cpu: "8"
-             memory: "20 G"
+             memory: "50 G"
              queue: queue
              job_group: jobGroup
      }


### PR DESCRIPTION
20G is not enough. 